### PR TITLE
Multi term highlighting

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -120,60 +120,67 @@ def execute_query_exact(index, term):
             return doc_id
 
 
-def highlight(query, terms, stemmer, analyzer):
+def ngram_to_term(ngram, stemmer, analyzer):
+    text = " ".join(ngram)
+    return next(tokenize(doc=text, stemmer=stemmer, analyzer=analyzer))
 
-    # Marked-up representation of the original query
-    markup = ''
+
+def find_best_match(ngram, terms):
+    best = (None, 0)
+    for term, n in terms.items():
+        if len(ngram) < n:
+            continue
+        matches = True
+        for idx, subterm in enumerate(term):
+            matches = matches and ngram[idx] == subterm
+        if matches and n > best[1]:
+            best = (term, n)
+    return best
+
+
+def highlight(query, terms, stemmer, analyzer):
     terms = {
         term: len(term)
         for term in terms
     }
     max_n = max(n for n in terms.values())
 
-    # Generate unstemmed ngrams of the same length as each query term
-    remaining_tokens = []
-    tag = 0
+    # Generate unstemmed ngrams of the maximum term length
+    ngrams = []
     for tokens in tokenize(doc=query, ngrams=max_n, analyzer=analyzer):
+        if len(tokens) < max_n:
+            break
+        ngrams.append(tokens)
 
-        # When full-length tokens are depleted, consume leftover tokens
-        if len(tokens) < max_n and len(remaining_tokens) > 0:
-            tokens = remaining_tokens
+    # Tail the ngram list with ngrams of decreasing length
+    final_ngram = ngrams[-1]
+    for n in range(0, max_n):
+        ngrams.append(final_ngram[n + 1:])
 
-        # Advance through the text, and close tags when they are complete
+    # Build up a marked-up representation of the original query
+    tag = 0
+    markup = ''
+    for ngram in ngrams:
+
+        # Advance through the text closing tags after their words are consumed
         tag -= 1
         if tag == 0:
             markup += "</mark>"
 
-        # Close a currently-open tag if we have consumed all tokens
-        if len(tokens) < max_n and tag > 0:
-            markup += f' {" ".join(tokens[:tag])}'
-            markup += "</mark>"
-            tokens = tokens[tag:]
-
-        # Write remaining entries to the output when tokens are depleted
-        if len(tokens) < max_n:
-            markup += f' {" ".join(tokens)}'
+        # Stop when we reach an empty end-of-stream ngram
+        if not ngram:
             break
+        if markup:
+            markup += " "
 
-        markup += " "
+        # Determine whether any of the highlighting terms match
+        ngram_term = ngram_to_term(ngram, stemmer, analyzer)
+        term, n = find_best_match(ngram_term, terms)
 
-        for term, n in terms.items():
+        # Begin markup if a match was found, and consume the next word token
+        if term:
+            markup += f"<mark>"
+            tag = n
+        markup += f"{ngram[0]}"
 
-            # Stem the original text to allow match equality comparsion
-            text = " ".join(tokens)
-            for stemmed_tokens in tokenize(
-                doc=text, ngrams=n, stemmer=stemmer, analyzer=analyzer
-            ):
-                break
-
-            # Open a tag marker when we find a matching term
-            if stemmed_tokens == term:
-                markup += f"<mark>"
-                tag = n
-                break
-
-        # Append the next consumed original token when we do not
-        markup += f"{tokens[0]}"
-        remaining_tokens = tokens[1:]
-
-    return markup.strip()
+    return markup

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -122,3 +122,16 @@ def test_phrase_term_highlighting():
     markup = highlight(doc, [term], stemmer, analyzer)
 
     assert markup == "can of <mark>baked beans</mark>"
+
+
+def test_phrase_multi_term_highlighting():
+    doc = "put the skewers in the frying pan"
+    terms = [("skewer",), ("frying", "pan",)]
+    expected = "put the <mark>skewers</mark> in the <mark>frying pan</mark>"
+
+    stemmer = NaivePluralStemmer()
+    analyzer = NullAnalyzer()
+
+    markup = highlight(doc, terms, stemmer, analyzer)
+
+    assert markup == expected

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -135,3 +135,16 @@ def test_phrase_multi_term_highlighting():
     markup = highlight(doc, terms, stemmer, analyzer)
 
     assert markup == expected
+
+
+def test_phrase_multi_term_highlighting_extra():
+    doc = "put the kebab skewers in the pan"
+    terms = [("kebab", "skewer",), ("pan",)]
+    expected = "put the <mark>kebab skewers</mark> in the <mark>pan</mark>"
+
+    stemmer = NaivePluralStemmer()
+    analyzer = NullAnalyzer()
+
+    markup = highlight(doc, terms, stemmer, analyzer)
+
+    assert markup == expected


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Recipe instructions frequently contain more than one term that we would like to extract and highlight.

For example, in future we would like to highlight the terms `oven` and `300 degrees` in the phrase `pre-heat the oven to 300 degrees`.

Although the initial implementation of highlighting looked like it might handle multiple terms (`oven`, `300 degrees`), in fact this was not working as expected.

### Briefly summarize the changes
1. Spent time reasoning about the stream of ngrams that will be processed
1. Refactored the `highlight` function to abstract some low-level operations
1. Updated commentary

### How have the changes been tested?
1. Unit tests are provided
