### PR TITLE
Retain original query formatting during highlighting

### DIFF
--- a/hashedixsearch/__init__.py
+++ b/hashedixsearch/__init__.py
@@ -6,6 +6,7 @@ from hashedixsearch.search import (  # noqa
     execute_query_exact,
     highlight,
     tokenize,
+    NullAnalyzer,
     NullStemmer,
     SynonymAnalyzer,
     WhitespaceTokenAnalyzer,

--- a/hashedixsearch/__init__.py
+++ b/hashedixsearch/__init__.py
@@ -6,7 +6,7 @@ from hashedixsearch.search import (  # noqa
     execute_query_exact,
     highlight,
     tokenize,
-    NullAnalyzer,
     NullStemmer,
     SynonymAnalyzer,
+    WhitespaceTokenAnalyzer,
 )

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -58,6 +58,7 @@ def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, analyzer=None):
             stemmer=stemmer,
             ignore_numeric=False,
             retain_casing=True,
+            retain_punctuation=True
         ):
             yield term
 

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -9,7 +9,6 @@ from hashedindex.textparser import (
 
 
 class NullAnalyzer:
-
     def process(self, input):
         return input
 
@@ -53,7 +52,12 @@ def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, analyzer=None):
 
     for ngrams in range(ngrams, 0, -1):
         for term in word_tokenize(
-            doc, stopwords, ngrams, stemmer=stemmer, ignore_numeric=False
+            doc,
+            stopwords,
+            ngrams,
+            stemmer=stemmer,
+            ignore_numeric=False,
+            retain_casing=True,
         ):
             yield term
 

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -8,6 +8,12 @@ from hashedindex.textparser import (
 )
 
 
+class NullAnalyzer:
+
+    def process(self, input):
+        return input
+
+
 class WhitespaceTokenAnalyzer:
 
     remove_punctuation = str.maketrans("", "", punctuation)

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -156,7 +156,7 @@ def find_best_match(ngram, terms):
     for term, n in terms.items():
 
         idx = 0
-        tokens = iter(term)
+        term = iter(term)
         matches = not ngram[idx].isspace()
 
         while matches and idx < min(n, ngram_length):
@@ -164,7 +164,7 @@ def find_best_match(ngram, terms):
                 idx += 1
                 n += 1
                 continue
-            if ngram[idx] == next(tokens):
+            if ngram[idx] == next(term):
                 idx += 1
                 continue
             matches = False

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -52,9 +52,9 @@ def tokenize(
 
     for ngrams in range(ngrams, 0, -1):
         for term in word_tokenize(
-            doc,
-            stopwords,
-            ngrams,
+            text=doc,
+            stopwords=stopwords,
+            ngrams=ngrams,
             stemmer=stemmer,
             ignore_numeric=False,
             retain_casing=retain_casing,

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -197,20 +197,12 @@ def highlight(query, terms, stemmer):
     # Build up a marked-up representation of the original query
     tag = 0
     markup = ""
-    prev_token = None
     for ngram in ngrams:
 
         # Advance through the text closing tags after their words are consumed
         tag -= 1
         if tag == 0:
-            if prev_token and prev_token.strip():
-                markup += prev_token
-                prev_token = None
             markup += "</mark>"
-
-        if prev_token:
-            markup += prev_token
-            prev_token = None
 
         # Stop when we reach an empty end-of-stream ngram
         if not ngram:
@@ -221,16 +213,9 @@ def highlight(query, terms, stemmer):
         term, n = find_best_match(ngram_term, terms)
 
         # Begin markup if a match was found, and consume the next word token
-        if ngram and ngram[0].strip() and term:
+        if term:
             markup += f"<mark>"
             tag = n
-
-        prev_token = f"{ngram[0]}"
-
-    if prev_token:
-        markup += prev_token
-
-    if tag > 0:
-        markup += "</mark>"
+        markup += f"{ngram[0]}"
 
     return markup

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -8,7 +8,7 @@ from hashedindex.textparser import (
 )
 
 
-class NullAnalyzer:
+class WhitespaceTokenAnalyzer:
 
     remove_punctuation = str.maketrans("", "", punctuation)
 
@@ -22,7 +22,7 @@ class NullAnalyzer:
         yield token
 
 
-class SynonymAnalyzer(NullAnalyzer):
+class SynonymAnalyzer(WhitespaceTokenAnalyzer):
     def __init__(self, synonyms):
         self.synonyms = synonyms
 
@@ -35,7 +35,7 @@ class SynonymAnalyzer(NullAnalyzer):
 def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, analyzer=None):
     stopwords = stopwords or []
     stemmer = stemmer or NullStemmer()
-    analyzer = analyzer or NullAnalyzer()
+    analyzer = analyzer or WhitespaceTokenAnalyzer()
 
     words = list(analyzer.process(doc))
     word_count = len(words)

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -168,7 +168,7 @@ def find_best_match(ngram, terms):
             matches = False
 
         if matches and n > best[1]:
-            best = term, n
+            best = (term, n)
     return best
 
 

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -46,7 +46,9 @@ def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, analyzer=None):
     ngrams = max(ngrams, 1)
 
     for ngrams in range(ngrams, 0, -1):
-        for term in word_tokenize(doc, stopwords, ngrams, stemmer=stemmer):
+        for term in word_tokenize(
+            doc, stopwords, ngrams, stemmer=stemmer, ignore_numeric=False
+        ):
             yield term
 
     # Produce an end-of-stream marker
@@ -139,10 +141,7 @@ def find_best_match(ngram, terms):
 
 
 def highlight(query, terms, stemmer, analyzer):
-    terms = {
-        term: len(term)
-        for term in terms
-    }
+    terms = {term: len(term) for term in terms}
     max_n = max(n for n in terms.values())
 
     # Generate unstemmed ngrams of the maximum term length
@@ -155,11 +154,11 @@ def highlight(query, terms, stemmer, analyzer):
     # Tail the ngram list with ngrams of decreasing length
     final_ngram = ngrams[-1]
     for n in range(0, max_n):
-        ngrams.append(final_ngram[n + 1:])
+        ngrams.append(final_ngram[n + 1 :])
 
     # Build up a marked-up representation of the original query
     tag = 0
-    markup = ''
+    markup = ""
     for ngram in ngrams:
 
         # Advance through the text closing tags after their words are consumed

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -141,15 +141,17 @@ def execute_query_exact(index, term):
 
 def ngram_to_term(ngram, stemmer):
     text = "".join(ngram)
-    return next(tokenize(doc=text, stemmer=stemmer, tokenize_whitespace=True))
+    return next(tokenize(
+        doc=text,
+        stemmer=stemmer,
+        retain_casing=True,
+        retain_punctuation=True,
+        tokenize_whitespace=True
+    ))
 
 
 def find_best_match(ngram, terms):
     best = (None, 0)
-    # TODO: remove
-    if not ngram:
-        return best
-
     ngram_length = len(ngram)
     for term, n in terms.items():
 

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -37,9 +37,16 @@ class SynonymAnalyzer(WhitespaceTokenAnalyzer):
             yield token
 
 
-def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, analyzer=None,
-             retain_casing=False, retain_punctuation=False,
-             tokenize_whitespace=False):
+def tokenize(
+    doc,
+    stopwords=None,
+    ngrams=None,
+    stemmer=None,
+    analyzer=None,
+    retain_casing=False,
+    retain_punctuation=False,
+    tokenize_whitespace=False,
+):
     stopwords = stopwords or []
     stemmer = stemmer or NullStemmer()
     analyzer = analyzer or WhitespaceTokenAnalyzer()
@@ -61,7 +68,7 @@ def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, analyzer=None,
             ignore_numeric=False,
             retain_casing=retain_casing,
             retain_punctuation=retain_punctuation,
-            tokenize_whitespace=tokenize_whitespace
+            tokenize_whitespace=tokenize_whitespace,
         ):
             yield term
 
@@ -138,11 +145,7 @@ def execute_query_exact(index, term):
 
 def ngram_to_term(ngram, stemmer, analyzer):
     text = " ".join((token for token in ngram if token.strip()))
-    return next(tokenize(
-        doc=text,
-        stemmer=stemmer,
-        analyzer=analyzer
-    ))
+    return next(tokenize(doc=text, stemmer=stemmer, analyzer=analyzer))
 
 
 def find_best_match(ngram, terms):
@@ -202,10 +205,6 @@ def highlight(query, terms, stemmer, analyzer):
             markup += prev_token
             prev_token = None
 
-        # Determine whether we are currently processing a whitespace token
-        if ngram and not ngram[0].strip():
-            whitespace = ngram[0]
-
         # Stop when we reach an empty end-of-stream ngram
         if not ngram:
             break
@@ -225,6 +224,6 @@ def highlight(query, terms, stemmer, analyzer):
         markup += prev_token
 
     if tag > 0:
-        markup += '</mark>'
+        markup += "</mark>"
 
     return markup

--- a/poetry.lock
+++ b/poetry.lock
@@ -94,7 +94,7 @@ description = "InvertedIndex implementation using hash lists (dictionaries)"
 name = "hashedindex"
 optional = false
 python-versions = "*"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 category = "dev"
@@ -276,7 +276,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "9100af9a5a4a4ad6c8331153748f46c8eb7045fc735e5c126da42f364a670e1b"
+content-hash = "323d766e8528c8a85aa8f4cd2f043387142e8a29d11608da3a91e871be7cea92"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -313,8 +313,8 @@ flake8 = [
     {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
 ]
 hashedindex = [
-    {file = "hashedindex-0.6.0-py2.py3-none-any.whl", hash = "sha256:f83f23575338e31e7950bdb67423ba10d58e5c66a9d4144315dbdb58bd2ac445"},
-    {file = "hashedindex-0.6.0.tar.gz", hash = "sha256:15f935eb1826754478df328a749db1202cb0d7b4da484bbe5337fcf574e6ed8f"},
+    {file = "hashedindex-0.7.0-py2.py3-none-any.whl", hash = "sha256:200465597354a7dc8b9754a79d3c957b33e345c17ebfdc3e117d5f0ea09c3d05"},
+    {file = "hashedindex-0.7.0.tar.gz", hash = "sha256:99fced4a421a6c8b972c887e9e786064f0cde5be902931794d0d02953344ac13"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/openculinary/hashedixsearch/"
 version = "0.1.1"
 
 [tool.poetry.dependencies]
-hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", rev = "48f78c8b779c6591c457b2200b0cdb1b996e69ed" }
+hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", rev = "e8bc314a681059a3bca56a3020aaee170a5cd05e" }
 python = "^3.7"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/openculinary/hashedixsearch/"
 version = "0.1.1"
 
 [tool.poetry.dependencies]
-hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", rev = "e8bc314a681059a3bca56a3020aaee170a5cd05e" }
+hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", rev = "e277a1269aa8b5b20d34cd73814f0cc390750693" }
 python = "^3.7"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/openculinary/hashedixsearch/"
 version = "0.1.1"
 
 [tool.poetry.dependencies]
-hashedindex = "^0.6.0"
+hashedindex = "^0.7.0"
 python = "^3.7"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/openculinary/hashedixsearch/"
 version = "0.1.1"
 
 [tool.poetry.dependencies]
-hashedindex = "^0.7.0"
+hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", rev = "48f78c8b779c6591c457b2200b0cdb1b996e69ed" }
 python = "^3.7"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/openculinary/hashedixsearch/"
 version = "0.1.1"
 
 [tool.poetry.dependencies]
-hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", rev = "e277a1269aa8b5b20d34cd73814f0cc390750693" }
+hashedindex = { git = "https://github.com/jayaddison/hashedindex.git", rev = "3a7e46a22c04960a0a50a2fca2d25cee7b4f9267" }
 python = "^3.7"
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -127,7 +127,7 @@ def test_highlighting():
 
     markup = highlight(doc, [term], stemmer, analyzer)
 
-    assert markup == "five <mark>onions</mark> diced"
+    assert markup == "five <mark>onions</mark>, diced"
 
 
 def test_phrase_term_highlighting():
@@ -181,7 +181,7 @@ def test_retain_numbers():
 def test_retained_style():
     doc = "Sentence one, oven.  Phrase two: pan."
     terms = [("oven",), ("pan",)]
-    expected = "Sentence one, <mark>oven</mark>. Phrase two: <mark>pan</mark>."
+    expected = "Sentence one, <mark>oven</mark>.  Phrase two: <mark>pan</mark>."
 
     stemmer = NaivePluralStemmer()
     analyzer = RetainPunctuationAnalyzer()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,5 @@
+from string import punctuation
+
 from hashedixsearch import (
     build_search_index,
     add_to_search_index,
@@ -6,6 +8,7 @@ from hashedixsearch import (
     execute_query_exact,
     highlight,
     tokenize,
+    NullAnalyzer,
     NullStemmer,
     SynonymAnalyzer,
     WhitespaceTokenAnalyzer,
@@ -18,9 +21,19 @@ class NaivePluralStemmer(NullStemmer):
         return word.rstrip("s")
 
 
-class RetainPunctuationAnalyzer(WhitespaceTokenAnalyzer):
-    def analyze_token(self, word):
-        yield word
+class RetainPunctuationAnalyzer(NullAnalyzer):
+    def process(self, input):
+        accumulator = []
+        for character in input:
+            if character in punctuation:
+                if accumulator:
+                    yield "".join(accumulator)
+                yield character
+                accumulator = []
+            else:
+                accumulator.append(character)
+        if accumulator:
+            yield "".join(accumulator)
 
 
 def test_tokenize_stopwords():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -6,9 +6,9 @@ from hashedixsearch import (
     execute_query_exact,
     highlight,
     tokenize,
-    NullAnalyzer,
     NullStemmer,
     SynonymAnalyzer,
+    WhitespaceTokenAnalyzer,
 )
 
 
@@ -39,7 +39,7 @@ def test_token_stemming():
 def test_null_analyzer_tokenization():
     doc = "coriander, chopped"
 
-    analyzer = NullAnalyzer()
+    analyzer = WhitespaceTokenAnalyzer()
     tokens = list(analyzer.process(doc))
 
     assert tokens == ["coriander", "chopped"]
@@ -105,7 +105,7 @@ def test_highlighting():
     term = ("onion",)
 
     stemmer = NaivePluralStemmer()
-    analyzer = NullAnalyzer()
+    analyzer = WhitespaceTokenAnalyzer()
 
     markup = highlight(doc, [term], stemmer, analyzer)
 
@@ -117,7 +117,7 @@ def test_phrase_term_highlighting():
     term = ("baked", "bean")
 
     stemmer = NaivePluralStemmer()
-    analyzer = NullAnalyzer()
+    analyzer = WhitespaceTokenAnalyzer()
 
     markup = highlight(doc, [term], stemmer, analyzer)
 
@@ -130,7 +130,7 @@ def test_phrase_multi_term_highlighting():
     expected = "put the <mark>skewers</mark> in the <mark>frying pan</mark>"
 
     stemmer = NaivePluralStemmer()
-    analyzer = NullAnalyzer()
+    analyzer = WhitespaceTokenAnalyzer()
 
     markup = highlight(doc, terms, stemmer, analyzer)
 
@@ -143,7 +143,7 @@ def test_phrase_multi_term_highlighting_extra():
     expected = "put the <mark>kebab skewers</mark> in the <mark>pan</mark>"
 
     stemmer = NaivePluralStemmer()
-    analyzer = NullAnalyzer()
+    analyzer = WhitespaceTokenAnalyzer()
 
     markup = highlight(doc, terms, stemmer, analyzer)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -179,9 +179,9 @@ def test_retain_numbers():
 
 
 def test_retained_style():
-    doc = "Sentence one, oven.  Phrase two: pan."
+    doc = "Step one, oven.  Phase two: pan."
     terms = [("oven",), ("pan",)]
-    expected = "Sentence one, <mark>oven</mark>.  Phrase two: <mark>pan</mark>."
+    expected = "Step one, <mark>oven</mark>.  Phase two: <mark>pan</mark>."
 
     stemmer = NaivePluralStemmer()
     analyzer = RetainPunctuationAnalyzer()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -18,11 +18,6 @@ class NaivePluralStemmer(NullStemmer):
         return word.rstrip("s")
 
 
-class RetainNumbersAnalyzer(WhitespaceTokenAnalyzer):
-    def analyze_token(self, word):
-        yield word
-
-
 class RetainPunctuationAnalyzer(WhitespaceTokenAnalyzer):
     def analyze_token(self, word):
         yield word
@@ -165,9 +160,7 @@ def test_retain_numbers():
     terms = [("oven",), ("300",)]
     expected = "preheat the <mark>oven</mark> to <mark>300</mark> degrees"
 
-    analyzer = RetainNumbersAnalyzer()
-
-    markup = highlight(doc, terms, stemmer=None, analyzer=analyzer)
+    markup = highlight(doc, terms, stemmer=None, analyzer=None)
 
     assert markup == expected
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -18,6 +18,16 @@ class NaivePluralStemmer(NullStemmer):
         return word.rstrip("s")
 
 
+class RetainNumbersAnalyzer(WhitespaceTokenAnalyzer):
+    def analyze_token(self, word):
+        yield word
+
+
+class RetainPunctuationAnalyzer(WhitespaceTokenAnalyzer):
+    def analyze_token(self, word):
+        yield word
+
+
 def test_tokenize_stopwords():
     doc = "red bell pepper diced"
     stopwords = ["diced"]
@@ -144,6 +154,31 @@ def test_phrase_multi_term_highlighting_extra():
 
     stemmer = NaivePluralStemmer()
     analyzer = WhitespaceTokenAnalyzer()
+
+    markup = highlight(doc, terms, stemmer, analyzer)
+
+    assert markup == expected
+
+
+def test_retain_numbers():
+    doc = "preheat the oven to 300 degrees"
+    terms = [("oven",), ("300",)]
+    expected = "preheat the <mark>oven</mark> to <mark>300</mark> degrees"
+
+    analyzer = RetainNumbersAnalyzer()
+
+    markup = highlight(doc, terms, stemmer=None, analyzer=analyzer)
+
+    assert markup == expected
+
+
+def test_retained_style():
+    doc = "Sentence one, oven.  Phrase two: pan."
+    terms = [("oven",), ("pan",)]
+    expected = "Sentence one, <mark>oven</mark>. Phrase two: <mark>pan</mark>."
+
+    stemmer = NaivePluralStemmer()
+    analyzer = RetainPunctuationAnalyzer()
 
     markup = highlight(doc, terms, stemmer, analyzer)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,3 @@
-from string import punctuation
-
 from hashedixsearch import (
     build_search_index,
     add_to_search_index,
@@ -8,7 +6,6 @@ from hashedixsearch import (
     execute_query_exact,
     highlight,
     tokenize,
-    NullAnalyzer,
     NullStemmer,
     SynonymAnalyzer,
     WhitespaceTokenAnalyzer,
@@ -19,21 +16,6 @@ class NaivePluralStemmer(NullStemmer):
     @staticmethod
     def stem(word):
         return word.rstrip("s")
-
-
-class RetainPunctuationAnalyzer(NullAnalyzer):
-    def process(self, input):
-        accumulator = []
-        for character in input:
-            if character in punctuation:
-                if accumulator:
-                    yield "".join(accumulator)
-                yield character
-                accumulator = []
-            else:
-                accumulator.append(character)
-        if accumulator:
-            yield "".join(accumulator)
 
 
 def test_tokenize_stopwords():


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Uses the case-preservation support from https://github.com/MichaelAquilina/hashedindex/pull/15 and punctuation-preservation support from https://github.com/MichaelAquilina/hashedindex/pull/16 to reconstruct highlighting markup that retains most of the original query text formatting.

### Briefly summarize the changes
- [x] Upgrade underlying `hashedindex` implementation
- [x] Enable format-preserving tokenization options
- [x] Implement an example format-preserving analyzer
- [x] Use format-preserving analyzer in the `highlight` function

### How have the changes been tested?
1. Unit tests are provided

Edit: fixup for checkbox markup