### PR TITLE
Remove analyzer parameter

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -37,7 +37,8 @@ class SynonymAnalyzer(WhitespaceTokenAnalyzer):
             yield token
 
 
-def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, tokenize_whitespace=False):
+def tokenize(doc, stopwords=None, ngrams=None, stemmer=None,
+             tokenize_whitespace=False):
     stopwords = stopwords or []
     ngrams = ngrams or 4
     stemmer = stemmer or NullStemmer()
@@ -48,7 +49,7 @@ def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, tokenize_whitespace
             stopwords=stopwords,
             ngrams=ngrams,
             stemmer=stemmer,
-            tokenize_whitespace=tokenize_whitespace
+            tokenize_whitespace=tokenize_whitespace,
         ):
             yield term
 
@@ -61,7 +62,7 @@ def add_to_search_index(
 ):
     if synonyms:
         analyzer = SynonymAnalyzer(synonyms)
-        doc = ' '.join(analyzer.process(doc))
+        doc = " ".join(analyzer.process(doc))
 
     stopwords = stopwords or []
     for term in tokenize(doc=doc, stopwords=stopwords, stemmer=stemmer):
@@ -97,7 +98,7 @@ def execute_query(
 
     if synonyms:
         analyzer = SynonymAnalyzer(synonyms)
-        query = ' '.join(analyzer.process(query))
+        query = " ".join(analyzer.process(query))
 
     query_count = 0
     for term in tokenize(doc=query, stopwords=stopwords, stemmer=stemmer):
@@ -171,7 +172,7 @@ def highlight(query, terms, stemmer):
     # Tail the ngram list with ngrams of decreasing length
     final_ngram = ngrams[-1]
     for n in range(0, max_n):
-        ngrams.append(final_ngram[n + 1 :])
+        ngrams.append(final_ngram[n+1:])
 
     # Build up a marked-up representation of the original query
     tag = 0

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -146,7 +146,7 @@ def find_best_match(ngram, terms):
     return best
 
 
-def highlight(query, terms, stemmer, analyzer):
+def highlight(query, terms, stemmer):
     terms = {term: len(term) for term in terms}
     max_n = max(n for n in terms.values())
 

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -135,12 +135,24 @@ def ngram_to_term(ngram, stemmer):
 
 def find_best_match(ngram, terms):
     best = (None, 0)
+    ngram_length = len(ngram)
     for term, n in terms.items():
-        if len(ngram) < n:
+        if n > ngram_length:
             continue
-        matches = True
-        for idx, subterm in enumerate(term):
-            matches = matches and ngram[idx] == subterm
+
+        idx = 0
+        matches = not ngram[idx].isspace()
+        for token in term:
+            if idx == ngram_length:
+                break
+            if ngram[idx].isspace():
+                idx += 1
+                n += 1
+            if idx == ngram_length:
+                break
+            matches = matches and ngram[idx] == token
+            idx += 1
+
         if matches and n > best[1]:
             best = (term, n)
     return best

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -137,21 +137,20 @@ def find_best_match(ngram, terms):
     best = (None, 0)
     ngram_length = len(ngram)
     for term, n in terms.items():
-        if n > ngram_length:
-            continue
 
         idx = 0
+        term = iter(term)
         matches = not ngram[idx].isspace()
-        for token in term:
-            if idx == ngram_length:
-                break
+
+        while matches and idx < min(n, ngram_length):
             if ngram[idx].isspace():
                 idx += 1
                 n += 1
-            if idx == ngram_length:
-                break
-            matches = matches and ngram[idx] == token
-            idx += 1
+                continue
+            if ngram[idx] == next(term):
+                idx += 1
+                continue
+            matches = False
 
         if matches and n > best[1]:
             best = (term, n)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -50,9 +50,9 @@ def test_token_synonyms():
     synonyms = {"soymilk": "soy milk"}
 
     analyzer = SynonymAnalyzer(synonyms=synonyms)
-    tokens = list(tokenize(doc=doc, analyzer=analyzer))
+    tokens = list(analyzer.process(doc))
 
-    assert tokens == [("soy", "milk"), ("soy",), ("milk",), ()]
+    assert tokens == ["soy", "milk"]
 
 
 def test_document_retrieval():
@@ -68,11 +68,10 @@ def test_document_retrieval():
 def test_analysis_consistency():
     doc = "soymilk"
     synonym = "soy milk"
-    analyzer = SynonymAnalyzer(synonyms={doc: synonym})
 
     index = build_search_index()
-    add_to_search_index(index, 0, "soymilk", analyzer=analyzer)
-    hits = execute_queries(index, ["soy milk"], analyzer=analyzer)
+    add_to_search_index(index, 0, "soymilk", synonyms={doc: synonym})
+    hits = execute_queries(index, ["soy milk"], synonyms={doc: synonym})
 
     assert list(hits)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -104,9 +104,8 @@ def test_highlighting():
     term = ("onion",)
 
     stemmer = NaivePluralStemmer()
-    analyzer = WhitespaceTokenAnalyzer()
 
-    markup = highlight(doc, [term], stemmer, analyzer)
+    markup = highlight(doc, [term], stemmer)
 
     assert markup == "five <mark>onions</mark> diced"
 
@@ -116,9 +115,8 @@ def test_phrase_term_highlighting():
     term = ("baked", "bean")
 
     stemmer = NaivePluralStemmer()
-    analyzer = WhitespaceTokenAnalyzer()
 
-    markup = highlight(doc, [term], stemmer, analyzer)
+    markup = highlight(doc, [term], stemmer)
 
     assert markup == "can of <mark>baked beans</mark>"
 
@@ -129,9 +127,8 @@ def test_phrase_multi_term_highlighting():
     expected = "put the <mark>skewers</mark> in the <mark>frying pan</mark>"
 
     stemmer = NaivePluralStemmer()
-    analyzer = WhitespaceTokenAnalyzer()
 
-    markup = highlight(doc, terms, stemmer, analyzer)
+    markup = highlight(doc, terms, stemmer)
 
     assert markup == expected
 
@@ -142,8 +139,7 @@ def test_phrase_multi_term_highlighting_extra():
     expected = "put the <mark>kebab skewers</mark> in the <mark>pan</mark>"
 
     stemmer = NaivePluralStemmer()
-    analyzer = WhitespaceTokenAnalyzer()
 
-    markup = highlight(doc, terms, stemmer, analyzer)
+    markup = highlight(doc, terms, stemmer)
 
     assert markup == expected


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
It's possible that the `analyzer` parameter will return to the `analyze` library function in the future; until then it seems sensible to simplify the interface to the library, especially since improved support for punctuation and whitespace tokenization may be available in `hashedindex` soon.

### Briefly summarize the changes
1. Remove the ability for library clients to supply custom tokenizers

### How have the changes been tested?
1. Unit test coverage is modified to match the updated library interface

Relates to #2 
