### PR TITLE
Handle error case: number of tokens in candidate term exceeds length of query tokens

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -191,6 +191,10 @@ def highlight(query, terms, stemmer):
             break
         ngrams.append(tokens)
 
+    # If we did not generate any ngrams, do not attempt highlighting
+    if not ngrams:
+        return query
+
     # Tail the ngram list with ngrams of decreasing length
     final_ngram = ngrams[-1]
     for n in range(0, max_n):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -110,6 +110,17 @@ def test_highlighting():
     assert markup == "five <mark>onions</mark>, diced"
 
 
+def test_highlighting_term_larger_than_query():
+    doc = "tofu"
+    term = ("pack", "tofu",)
+
+    stemmer = NaivePluralStemmer()
+
+    markup = highlight(doc, [term], stemmer)
+
+    assert markup == "tofu"
+
+
 def test_phrase_term_highlighting():
     doc = "can of baked beans"
     term = ("baked", "bean")


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change prevents an error condition during which callers may experience an `IndexError: list index out of range` exception if they attempt to run the `highlight` function on a query that contains fewer tokens that one of the candidate `terms` provided. 

### Briefly summarize the changes
1. Do not attempt to highlight when no candidate term ngrams are generated

### How have the changes been tested?
1. Unit test coverage is provided

**List any issues that this change relates to**
Fixes #4 
