### PR TITLE
Highlighting: add synonym support

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -174,9 +174,13 @@ def longest_prefix(ngram, terms):
     return prefix_length
 
 
-def highlight(query, terms, stemmer):
+def highlight(query, terms, stemmer, synonyms=None):
     terms = {term: len(term) for term in terms}
     max_n = max(n for n in terms.values())
+
+    if synonyms:
+        analyzer = SynonymAnalyzer(synonyms)
+        query = " ".join(analyzer.process(query))
 
     # Generate unstemmed ngrams of the maximum term length
     ngrams = []

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -121,6 +121,18 @@ def test_phrase_term_highlighting():
     assert markup == "can of <mark>baked beans</mark>"
 
 
+def test_synonym_highlighting():
+    doc = "soymilk"
+    term = ("soy", "milk")
+
+    stemmer = NaivePluralStemmer()
+    synonyms = {"soymilk": "soy milk"}
+
+    markup = highlight(doc, [term], stemmer, synonyms)
+
+    assert markup == "<mark>soy milk</mark>"
+
+
 def test_phrase_multi_term_highlighting():
     doc = "put the skewers in the frying pan"
     terms = [("skewer",), ("frying", "pan",)]


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Currently the majority of API methods exposed by `hashedixsearch` provide the ability for the caller to supply a list of `synonyms` to be applied to the input document/query.

The `highlight` function has lacked this capability, and this pull request introduces it.

### Briefly summarize the changes
1. Add an optional `synonyms` argument to the `highlight` function and implement synonym handling

### How have the changes been tested?
1. Unit test coverage is provided