### PR TITLE
API Consistency: Highlighting: make stemmer optional

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -174,7 +174,7 @@ def longest_prefix(ngram, terms):
     return prefix_length
 
 
-def highlight(query, terms, stemmer, synonyms=None):
+def highlight(query, terms, stemmer=None, synonyms=None):
     terms = {term: len(term) for term in terms}
     max_n = max(n for n in terms.values())
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -110,6 +110,15 @@ def test_highlighting():
     assert markup == "five <mark>onions</mark>, diced"
 
 
+def test_highlighting_unstemmed():
+    doc = "one carrot"
+    term = ("carrot",)
+
+    markup = highlight(doc, [term])
+
+    assert markup == "one <mark>carrot</mark>"
+
+
 def test_highlighting_term_larger_than_query():
     doc = "tofu"
     term = ("pack", "tofu",)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
In all API methods exposed by `hashedixsearch` except for the `highlight` method, the `stemmer` argument is optional.  This is an oversight and this changeset brings that method into consistency with the rest.

### Briefly summarize the changes
1. Make `stemmer` argument to `highlight` function optional

### How have the changes been tested?
1. Unit test coverage is provided