### PR TITLE
Clarify that utility methods are internal

### DIFF
--- a/hashedixsearch/_internal.py
+++ b/hashedixsearch/_internal.py
@@ -1,0 +1,36 @@
+import hashedixsearch.search
+
+
+def _ngram_to_term(ngram, stemmer):
+    text = "".join(ngram)
+    return next(hashedixsearch.search.tokenize(
+        doc=text,
+        stemmer=stemmer,
+        retain_casing=True,
+        retain_punctuation=True,
+        tokenize_whitespace=True
+    ))
+
+
+def _longest_prefix(ngram, terms):
+    prefix_length = 0
+    ngram_length = len(ngram)
+    for term, n in terms.items():
+
+        idx = 0
+        term = iter(term)
+        matches = not ngram[idx].isspace()
+
+        while matches and idx < min(n, ngram_length):
+            if ngram[idx].isspace():
+                idx += 1
+                n += 1
+                continue
+            if ngram[idx] == next(term):
+                idx += 1
+                continue
+            matches = False
+
+        if matches and n > prefix_length:
+            prefix_length = n
+    return prefix_length


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change does not affect any of the behaviour or functionality of the library, but does clarify that two utility methods (previously named `ngram_to_term` and `longest_prefix` are for internal library usage only.

This is done two-fold by prefixing the method names with an underscore and also by moving them into a module with the filename `_internal.py`.

### How have the changes been tested?
1. Existing test coverage continues to pass