### PR TITLE
Analyzes: Rebase SynonymAnalyzer onto punctuation-handling analyzer

### DIFF
--- a/hashedixsearch/__init__.py
+++ b/hashedixsearch/__init__.py
@@ -9,5 +9,6 @@ from hashedixsearch.search import (  # noqa
     NullAnalyzer,
     NullStemmer,
     SynonymAnalyzer,
+    WhitespacePunctuationTokenAnalyzer,
     WhitespaceTokenAnalyzer,
 )

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -51,18 +51,9 @@ class SynonymAnalyzer(WhitespacePunctuationTokenAnalyzer):
         self.synonyms = synonyms
 
     def analyze_token(self, token):
-        synonym = self.synonyms.get(token)
-        if synonym is None:
+        synonym = self.synonyms.get(token) or token
+        for token in re.split("( )", synonym):
             yield token
-            return
-
-        tokens = iter(synonym.split(" "))
-        head = next(tokens)
-        tail = next(tokens, None)
-        yield head
-        if tail:
-            yield " "
-            yield tail
 
 
 def tokenize(

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -100,7 +100,7 @@ def add_to_search_index(
 ):
     if synonyms:
         analyzer = SynonymAnalyzer(synonyms)
-        doc = "".join(analyzer.process(doc))
+        doc = str().join(analyzer.process(doc))
 
     stopwords = stopwords or []
     for term in tokenize(doc=doc, stopwords=stopwords, stemmer=stemmer):
@@ -136,7 +136,7 @@ def execute_query(
 
     if synonyms:
         analyzer = SynonymAnalyzer(synonyms)
-        query = "".join(analyzer.process(query))
+        query = str().join(analyzer.process(query))
 
     query_count = 0
     for term in tokenize(doc=query, stopwords=stopwords, stemmer=stemmer):
@@ -173,7 +173,7 @@ def highlight(query, terms, stemmer=None, synonyms=None):
 
     if synonyms:
         analyzer = SynonymAnalyzer(synonyms)
-        query = "".join(analyzer.process(query))
+        query = str().join(analyzer.process(query))
 
     # Generate unstemmed ngrams of the maximum term length
     ngrams = []

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -52,7 +52,7 @@ class SynonymAnalyzer(WhitespacePunctuationTokenAnalyzer):
 
     def analyze_token(self, token):
         synonym = self.synonyms.get(token) or token
-        for token in re.split("( )", synonym):
+        for token in re.split(r"(\w+)", synonym):
             yield token
 
 

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -38,10 +38,9 @@ class WhitespacePunctuationTokenAnalyzer:
 
     def process(self, input):
         for token in re.split(self.delimiters, input):
-            if not token:
-                break
             for analyzed_token in self.analyze_token(token):
-                yield analyzed_token
+                if analyzed_token:
+                    yield analyzed_token
 
     def analyze_token(self, token):
         yield token

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -34,7 +34,7 @@ class WhitespaceTokenAnalyzer:
 
 class WhitespacePunctuationTokenAnalyzer:
 
-    delimiters = rf'([ {punctuation}])'
+    delimiters = rf'([\s+|{punctuation}])'
 
     def process(self, input):
         for token in re.split(self.delimiters, input):

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -52,7 +52,7 @@ class SynonymAnalyzer(WhitespacePunctuationTokenAnalyzer):
 
     def analyze_token(self, token):
         synonym = self.synonyms.get(token) or token
-        for token in re.split(r"(\w+)", synonym):
+        for token in re.split(r"(\s+)", synonym):
             yield token
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -52,7 +52,7 @@ def test_whitespace_punctuation_analyzer_tokenization():
     analyzer = WhitespacePunctuationTokenAnalyzer()
     tokens = list(analyzer.process(doc))
 
-    assert tokens == ["coriander", ",", "chopped"]
+    assert tokens == ["coriander", ",", " ", "chopped"]
 
 
 def test_token_synonyms():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -9,6 +9,7 @@ from hashedixsearch import (
     NullStemmer,
     SynonymAnalyzer,
     WhitespaceTokenAnalyzer,
+    WhitespacePunctuationTokenAnalyzer,
 )
 
 
@@ -43,6 +44,15 @@ def test_whitespace_analyzer_tokenization():
     tokens = list(analyzer.process(doc))
 
     assert tokens == ["coriander", "chopped"]
+
+
+def test_whitespace_punctuation_analyzer_tokenization():
+    doc = "coriander, chopped"
+
+    analyzer = WhitespacePunctuationTokenAnalyzer()
+    tokens = list(analyzer.process(doc))
+
+    assert tokens == ["coriander", ",", "chopped"]
 
 
 def test_token_synonyms():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -36,7 +36,7 @@ def test_token_stemming():
     assert tokens[0] == ("onion",)
 
 
-def test_null_analyzer_tokenization():
+def test_whitespace_analyzer_tokenization():
     doc = "coriander, chopped"
 
     analyzer = WhitespaceTokenAnalyzer()
@@ -46,13 +46,13 @@ def test_null_analyzer_tokenization():
 
 
 def test_token_synonyms():
-    doc = "soymilk"
+    doc = "soymilk."
     synonyms = {"soymilk": "soy milk"}
 
     analyzer = SynonymAnalyzer(synonyms=synonyms)
     tokens = list(analyzer.process(doc))
 
-    assert tokens == ["soy", "milk"]
+    assert tokens == ["soy", " ", "milk", "."]
 
 
 def test_document_retrieval():
@@ -142,7 +142,7 @@ def test_phrase_term_highlighting():
 
 
 def test_synonym_highlighting():
-    doc = "soymilk"
+    doc = "soymilk."
     term = ("soy", "milk")
 
     stemmer = NaivePluralStemmer()
@@ -150,7 +150,7 @@ def test_synonym_highlighting():
 
     markup = highlight(doc, [term], stemmer, synonyms)
 
-    assert markup == "<mark>soy milk</mark>"
+    assert markup == "<mark>soy milk</mark>."
 
 
 def test_phrase_multi_term_highlighting():


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The recently-added synonym highlighting support in #6 surfaced an issue whereby documents containing punctuation *and* synonyms were not correctly handled during highlighting.

This was due to the `SynonymAnalyzer` using the `WhitespaceTokenAnalyzer` base class; it [splits on whitespace and removes punctuation](https://github.com/openculinary/hashedixsearch/blob/d92b3cffedeade4bb9bbbc00316f682661730e00/hashedixsearch/search.py#L25-L26).

This change re-bases the `SynonymAnalyzer` onto a `WhitespacePunctuationTokenAnalyzer` that retains punctuation and whitespace tokens.

### How have the changes been tested?
1. Unit test coverage is updated and added