### PR TITLE
Analysis/remove from library interface

### DIFF
--- a/hashedixsearch/__init__.py
+++ b/hashedixsearch/__init__.py
@@ -6,9 +6,5 @@ from hashedixsearch.search import (  # noqa
     execute_query_exact,
     highlight,
     tokenize,
-    NullAnalyzer,
     NullStemmer,
-    SynonymAnalyzer,
-    WhitespacePunctuationTokenAnalyzer,
-    WhitespaceTokenAnalyzer,
 )

--- a/hashedixsearch/_internal.py
+++ b/hashedixsearch/_internal.py
@@ -1,6 +1,31 @@
+import re
 from string import punctuation
 
 import hashedixsearch.search
+
+
+class WhitespacePunctuationTokenAnalyzer:
+
+    delimiters = rf'([\s+|{punctuation}])'
+
+    def process(self, input):
+        for token in re.split(self.delimiters, input):
+            for analyzed_token in self.analyze_token(token):
+                if analyzed_token:
+                    yield analyzed_token
+
+    def analyze_token(self, token):
+        yield token
+
+
+class SynonymAnalyzer(WhitespacePunctuationTokenAnalyzer):
+    def __init__(self, synonyms):
+        self.synonyms = synonyms
+
+    def analyze_token(self, token):
+        synonym = self.synonyms.get(token) or token
+        for token in re.split(r"(\s+)", synonym):
+            yield token
 
 
 def _ngram_to_term(ngram, stemmer):

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -13,20 +13,6 @@ from hashedixsearch._internal import (
 )
 
 
-class WhitespaceTokenAnalyzer:
-
-    remove_punctuation = str.maketrans("", "", punctuation)
-
-    def process(self, input):
-        for token in input.split(" "):
-            token = token.translate(self.remove_punctuation)
-            for result in self.analyze_token(token):
-                yield result
-
-    def analyze_token(self, token):
-        yield token
-
-
 class WhitespacePunctuationTokenAnalyzer:
 
     delimiters = rf'([\s+|{punctuation}])'

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -1,6 +1,4 @@
 from collections import defaultdict
-import re
-from string import punctuation
 
 from hashedindex import HashedIndex
 from hashedindex.textparser import (
@@ -10,31 +8,8 @@ from hashedindex.textparser import (
 from hashedixsearch._internal import (
     _longest_prefix,
     _ngram_to_term,
+    SynonymAnalyzer,
 )
-
-
-class WhitespacePunctuationTokenAnalyzer:
-
-    delimiters = rf'([\s+|{punctuation}])'
-
-    def process(self, input):
-        for token in re.split(self.delimiters, input):
-            for analyzed_token in self.analyze_token(token):
-                if analyzed_token:
-                    yield analyzed_token
-
-    def analyze_token(self, token):
-        yield token
-
-
-class SynonymAnalyzer(WhitespacePunctuationTokenAnalyzer):
-    def __init__(self, synonyms):
-        self.synonyms = synonyms
-
-    def analyze_token(self, token):
-        synonym = self.synonyms.get(token) or token
-        for token in re.split(r"(\s+)", synonym):
-            yield token
 
 
 def tokenize(

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -13,11 +13,6 @@ from hashedixsearch._internal import (
 )
 
 
-class NullAnalyzer:
-    def process(self, input):
-        return input
-
-
 class WhitespaceTokenAnalyzer:
 
     remove_punctuation = str.maketrans("", "", punctuation)

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,0 +1,23 @@
+from hashedixsearch._internal import (
+    SynonymAnalyzer,
+    WhitespacePunctuationTokenAnalyzer,
+)
+
+
+def test_whitespace_punctuation_analyzer_tokenization():
+    doc = "coriander, chopped"
+
+    analyzer = WhitespacePunctuationTokenAnalyzer()
+    tokens = list(analyzer.process(doc))
+
+    assert tokens == ["coriander", ",", " ", "chopped"]
+
+
+def test_token_synonyms():
+    doc = "soymilk."
+    synonyms = {"soymilk": "soy milk"}
+
+    analyzer = SynonymAnalyzer(synonyms=synonyms)
+    tokens = list(analyzer.process(doc))
+
+    assert tokens == ["soy", " ", "milk", "."]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -7,8 +7,6 @@ from hashedixsearch.search import (
     highlight,
     tokenize,
     NullStemmer,
-    SynonymAnalyzer,
-    WhitespacePunctuationTokenAnalyzer,
 )
 
 
@@ -34,25 +32,6 @@ def test_token_stemming():
     tokens = list(tokenize(doc=doc, stemmer=NaivePluralStemmer))
 
     assert tokens[0] == ("onion",)
-
-
-def test_whitespace_punctuation_analyzer_tokenization():
-    doc = "coriander, chopped"
-
-    analyzer = WhitespacePunctuationTokenAnalyzer()
-    tokens = list(analyzer.process(doc))
-
-    assert tokens == ["coriander", ",", " ", "chopped"]
-
-
-def test_token_synonyms():
-    doc = "soymilk."
-    synonyms = {"soymilk": "soy milk"}
-
-    analyzer = SynonymAnalyzer(synonyms=synonyms)
-    tokens = list(analyzer.process(doc))
-
-    assert tokens == ["soy", " ", "milk", "."]
 
 
 def test_document_retrieval():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,4 @@
-from hashedixsearch import (
+from hashedixsearch.search import (
     build_search_index,
     add_to_search_index,
     execute_queries,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,7 +8,6 @@ from hashedixsearch import (
     tokenize,
     NullStemmer,
     SynonymAnalyzer,
-    WhitespaceTokenAnalyzer,
     WhitespacePunctuationTokenAnalyzer,
 )
 
@@ -35,15 +34,6 @@ def test_token_stemming():
     tokens = list(tokenize(doc=doc, stemmer=NaivePluralStemmer))
 
     assert tokens[0] == ("onion",)
-
-
-def test_whitespace_analyzer_tokenization():
-    doc = "coriander, chopped"
-
-    analyzer = WhitespaceTokenAnalyzer()
-    tokens = list(analyzer.process(doc))
-
-    assert tokens == ["coriander", "chopped"]
 
 
 def test_whitespace_punctuation_analyzer_tokenization():


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Currently it doens't seem hugely useful for the analysis-related classes to be made accessible outside of the `hashedixsearch` library interface.  They may return later, but for now to keep things simple they are moved to internal modules and no longer exposed.