### PR TITLE
Highlighting: handle empty terms

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -123,6 +123,11 @@ def execute_query_exact(index, term):
 
 
 def highlight(query, terms, stemmer=None, synonyms=None):
+
+    # If no terms are provided to match on, do not attempt highlighting
+    if not terms:
+        return query
+
     terms = {term: list(term) for term in terms}
     max_n = max(len(term) for term in terms.values())
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -98,6 +98,14 @@ def test_highlighting_unstemmed():
     assert markup == "one <mark>carrot</mark>"
 
 
+def test_highlighting_empty_terms():
+    doc = "mushrooms"
+
+    markup = highlight(doc, [])
+
+    assert markup == doc
+
+
 def test_highlighting_term_larger_than_query():
     doc = "tofu"
     term = ("pack", "tofu",)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset handles an edge case where the caller supplies an empty list of terms to highlight on.  When that occurs, there is no sense in tokenizing the query and attempting to find terms to highlight; we simply return the query.

### How have the changes been tested?
1. Test coverage is provided