### PR TITLE
Highlighting: Provide configurable case-sensitivity

### DIFF
--- a/hashedixsearch/_internal.py
+++ b/hashedixsearch/_internal.py
@@ -28,12 +28,12 @@ class SynonymAnalyzer(WhitespacePunctuationTokenAnalyzer):
             yield token
 
 
-def _ngram_to_term(ngram, stemmer):
+def _ngram_to_term(ngram, stemmer, case_sensitive):
     text = "".join(ngram)
     return next(hashedixsearch.search.tokenize(
         doc=text,
         stemmer=stemmer,
-        retain_casing=True,
+        retain_casing=case_sensitive,
         retain_punctuation=True,
         tokenize_whitespace=True
     ))

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -122,7 +122,7 @@ def execute_query_exact(index, term):
             return doc_id
 
 
-def highlight(query, terms, stemmer=None, synonyms=None):
+def highlight(query, terms, stemmer=None, synonyms=None, case_sensitive=True):
 
     # If no terms are provided to match on, do not attempt highlighting
     if not terms:
@@ -164,7 +164,7 @@ def highlight(query, terms, stemmer=None, synonyms=None):
             break
 
         # Determine whether any of the highlighting terms match
-        ngram_term = _ngram_to_term(ngram, stemmer)
+        ngram_term = _ngram_to_term(ngram, stemmer, case_sensitive)
         longest_term = _longest_prefix(ngram_term, terms)
 
         # Begin markup if a prefix match was found

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -98,6 +98,24 @@ def test_highlighting_unstemmed():
     assert markup == "one <mark>carrot</mark>"
 
 
+def test_highlighting_case_insensitive_term():
+    doc = "Wine"
+    term = ("wine",)
+
+    markup = highlight(doc, [term], case_sensitive=False)
+
+    assert markup == "<mark>Wine</mark>"
+
+
+def test_highlighting_case_insensitive_phrase():
+    doc = "Place in Dutch Oven, and leave for one hour"
+    term = ("dutch", "oven")
+
+    markup = highlight(doc, [term], case_sensitive=False)
+
+    assert markup == "Place in <mark>Dutch Oven</mark>, and leave for one hour"
+
+
 def test_highlighting_empty_terms():
     doc = "mushrooms"
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Callers may wish to highlight terms in a case sensitive or case-insensitive manner.  This change adds support for configurable case sensitivity.

### Briefly summarize the changes
1. When generating internal ngram 'comparison tokens' during highlighting, retain original casing during case-sensitive highlighting, and drop original casing for case-insensitive highlighting

### How have the changes been tested?
1. Unit test coverage is provided

**List any issues that this change relates to**
Relates to https://github.com/openculinary/frontend/issues/130
