### PR TITLE
Highlighting: Ensure that partial term matches do not occur

### DIFF
--- a/hashedixsearch/_internal.py
+++ b/hashedixsearch/_internal.py
@@ -66,13 +66,17 @@ def _longest_prefix(ngram, terms):
 
         # Consume from the ngram and term streams in parallel
         while ngram_token and term_token:
+            while _is_separator(ngram_token):
+                ngram_token = next(ngram_tokens, None)
             if ngram_token == term_token:
                 ngram_token = next(ngram_tokens, None)
                 term_token = next(term_tokens, None)
-            if _is_separator(ngram_token):
-                ngram_token = next(ngram_tokens, None)
             else:
-                term_token = next(term_tokens, None)
+                break
+
+        # Discard trailing ngram separators
+        while _is_separator(ngram_token):
+            ngram_token = next(ngram_tokens, None)
 
         # If the ngram stream was fully consumed, record the longest term
         if ngram_token is None and len(term) > len(longest_term):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -116,6 +116,15 @@ def test_highlighting_case_insensitive_phrase():
     assert markup == "Place in <mark>Dutch Oven</mark>, and leave for one hour"
 
 
+def test_highlighting_partial_match_ignored():
+    doc = "Place in Dutch oven, and leave for one hour"
+    term = ("dutch", "oven")
+
+    markup = highlight(doc, [term])
+
+    assert markup == "Place in Dutch oven, and leave for one hour"
+
+
 def test_highlighting_empty_terms():
     doc = "mushrooms"
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The second word, 'oven', in the highlight term 'dutch oven' was being *partially matched* on the phrase 'Dutch oven' during a case-sensitive highlight operation.

This resulted in an output containing `<mark>oven` -- but since not all of the match terms were consumed, no closing `</mark>` tag was emitted.

### Briefly summarize the changes
1. Ensure that partial term matches do not occur

### How have the changes been tested?
1. Test coverage is provided

**List any issues that this change relates to**
Relates to https://github.com/openculinary/frontend/issues/130
