### PR TITLE
Highlighting: allow repeat matches

### DIFF
--- a/hashedixsearch/_internal.py
+++ b/hashedixsearch/_internal.py
@@ -1,3 +1,4 @@
+from copy import copy
 import re
 from string import punctuation
 
@@ -82,4 +83,5 @@ def _longest_prefix(ngram, terms):
         if ngram_token is None and len(term) > len(longest_term):
             longest_term = term
 
-    return longest_term
+    # Return a mutable copy of the longest term
+    return copy(longest_term)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -125,6 +125,15 @@ def test_highlighting_partial_match_ignored():
     assert markup == "Place in Dutch oven, and leave for one hour"
 
 
+def test_highlighting_repeat_match():
+    doc = "daal daal daal"
+    term = ("daal",)
+
+    markup = highlight(doc, [term])
+
+    assert markup == "<mark>daal</mark> <mark>daal</mark> <mark>daal</mark>"
+
+
 def test_highlighting_empty_terms():
     doc = "mushrooms"
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
It's completely valid for a highlighted term to appear multiple times within a document.

This change fixes an unintentional previous behaviour whereby only the first occurrence of the term in the document would be highlighted.

### Briefly summarize the changes
1. When we find a matching term, we open a `<mark>` tag and then gradually 'pop' elements from a matching term until all of its tokens are consumed; when all tokens are consumed, we emit a `</mark>` closing tag.  Unfortunately we had been popping elements not just from the 'tracking tag' tuples, but also from the match tuples themselves.  The change here makes a mutable copy of the matching term so that the tag tuple can be modified without affecting later match attempts.

### How have the changes been tested?
1. Unit test coverage is provided