### PR TITLE
Highlighting: escape XML entities

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from xml.sax.saxutils import escape
 
 from hashedindex import HashedIndex
 from hashedindex.textparser import (
@@ -169,11 +170,11 @@ def highlight(query, terms, stemmer=None, synonyms=None, case_sensitive=True):
 
         # Begin markup if a prefix match was found
         if longest_term and longest_term != tag:
-            markup += f"<mark>"
+            markup += "<mark>"
             tag = longest_term
 
         # Consume one token at a time
-        markup += f"{ngram[0]}"
+        markup += escape(ngram[0])
 
         # Close markup when all of a tag's tokens are consumed
         if tag and tag[0] == ngram_term[0]:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -89,6 +89,17 @@ def test_highlighting():
     assert markup == "five <mark>onions</mark>, diced"
 
 
+def test_highlighting_escaping():
+    doc = "egg & bacon"
+    terms = [("egg",), ("bacon",)]
+
+    stemmer = NaivePluralStemmer()
+
+    markup = highlight(doc, terms, stemmer)
+
+    assert markup == "<mark>egg</mark> &amp; <mark>bacon</mark>"
+
+
 def test_highlighting_unstemmed():
     doc = "one carrot"
     term = ("carrot",)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Since the markup that the `highlight` method returns is intended to be XML-formatted, it should ensure that string content is correctly XML escaped.

For example, an ampersand (`&`) in the input query should be transformed into an ampersand XML entity (`&amp;`) in the output.

### Briefly summarize the changes
1. Apply XML escaping to the contents of the highlighted markup

### How have the changes been tested?
1. Unit test coverage is provided

**List any issues that this change relates to**
Relates to https://github.com/openculinary/frontend/issues/130
