### PR TITLE
Bugfix: trailing partial matches

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -250,3 +250,13 @@ def test_ambiguous_prefix():
     markup = highlight(doc, terms, stemmer)
 
     assert markup == "<mark>food mill</mark>."
+
+
+def test_partial_suffix():
+    doc = "medium onion"
+    terms = [("onion", "gravy")]
+
+    stemmer = NaivePluralStemmer()
+    markup = highlight(doc, terms, stemmer)
+
+    assert markup == "medium onion"


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
If a matching highlight term (for example, `onion gravy`) appears to be a possible match at the end of a token stream (for example, `medium onion`), then the highlighter emits an opening tag before the stream is consumed.

This results in a trailing open tag.  The correct behaviour is that we need to wait until we have consumed all of the tokens from the potential match, and only emit the accumulated content (enclosed by opening and closing tags) at that point.

### How have the changes been tested?
1. Unit test coverage is provided