### PR TITLE
Highlighting: add support for per-term custom attributes

### DIFF
--- a/hashedixsearch/_internal.py
+++ b/hashedixsearch/_internal.py
@@ -1,5 +1,6 @@
 import re
 from string import punctuation
+from xml.etree.ElementTree import Element, tostring
 
 import hashedixsearch.search
 
@@ -86,3 +87,9 @@ def _candidate_matches(ngram, terms):
         for term, term_tokens in terms.items()
         if term in candidates
     }
+
+
+def _render_match(text, attributes):
+    element = Element("mark", attributes or {})
+    element.text = text
+    return tostring(element, encoding="unicode")

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -163,7 +163,6 @@ def highlight(query, terms, stemmer=None, synonyms=None, case_sensitive=True,
     tag = None
     markup = ""
     accumulator = ""
-    attributes = None
 
     for ngram in ngrams:
 

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -188,7 +188,8 @@ def highlight(query, terms, stemmer=None, synonyms=None, case_sensitive=True):
             }
 
             # Close the markup when any term's tokens have been consumed
-            if not all(tag.values()):
+            closing_term = next(filter(lambda k: not tag[k], tag), None)
+            if closing_term:
                 accumulator = f"<mark>{accumulator}</mark>"
                 emit = True
                 tag = None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -283,12 +283,12 @@ def test_partial_suffix():
 
 def test_term_attributes():
     doc = "garlic"
-    term_garlic = ("garlic",)
+    term = ("garlic",)
 
-    terms = [term_garlic]
-    term_attributes = {term_garlic: {"name": "garlic"}}
+    terms = [term]
+    term_attributes = {term: {"id": "example"}}
 
     stemmer = NaivePluralStemmer()
     markup = highlight(doc, terms, stemmer, term_attributes=term_attributes)
 
-    assert markup == '<mark name="garlic">garlic</mark>'
+    assert markup == '<mark id="example">garlic</mark>'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -279,3 +279,16 @@ def test_partial_suffix():
     markup = highlight(doc, terms, stemmer)
 
     assert markup == "medium onion"
+
+
+def test_term_attributes():
+    doc = "garlic"
+    term_garlic = ("garlic",)
+
+    terms = [term_garlic]
+    term_attributes = {term_garlic: {"name": "garlic"}}
+
+    stemmer = NaivePluralStemmer()
+    markup = highlight(doc, terms, stemmer, term_attributes=term_attributes)
+
+    assert markup == '<mark name="garlic">garlic</mark>'


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Currently the `highlight` method returns markup that renders term matches by using a `<mark>...</mark>` XML element.

At the moment it's not possible for the caller to include metadata with each of these highlight matches.  This changeset adds an optional `term_attributes` argument that allows the caller to annotate each match with an arbitrary set of key=value attribute pairs, rendered as XML attributes.

### Briefly summarize the changes
1. Add the optional `term_attributes` argument
1. When we identify that a match has been completed, retrieve a reference to term that closed the text match
1. Extract a `_render_match` method to perform match rendering with the appropriate attributes (if any)

### How have the changes been tested?
1. Unit test coverage is provided