### PR TITLE
Use query term match count as a hit scoring tie-breaker

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -292,3 +292,31 @@ def test_term_attributes():
     markup = highlight(doc, terms, stemmer, term_attributes=term_attributes)
 
     assert markup == '<mark id="example">garlic</mark>'
+
+
+def test_hit_scoring():
+    precise_match = "garlic"
+    imprecise_match = "clove garlic"
+
+    index = build_search_index()
+    add_to_search_index(index, 0, precise_match)
+    add_to_search_index(index, 1, imprecise_match)
+
+    hits = execute_query(index, "garlic")
+
+    assert len(hits) == 2
+    assert hits[0]['doc_id'] == 0
+
+
+def test_term_frequency_tiebreaker():
+    infrequent_doc = "clove"
+    frequent_doc = "garlic"
+
+    index = build_search_index()
+    add_to_search_index(index, 0, infrequent_doc)
+    add_to_search_index(index, 1, frequent_doc, count=5)
+
+    hits = execute_query(index, "garlic clove", query_limit=-1)
+
+    assert len(hits) == 2
+    assert hits[0]['doc_id'] == 1


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
In some situations, query hits may have equal calculated scores.  The base hit score is calculated by taking the term frequency and dividing it by the length of the document.

This change introduces a tie-breaker in the sort order for query hits.  In cases where the calculated scores are equal, the count of all term matches for the hit within the document is used.  A higher count indicates more matching term occurrences, and wins the tiebreaker.

### Briefly summarize the changes
1. Count the per-document term matches within a document at query-time
1. Use the per-document match count as a tie-breaker during query result sorting

### How have the changes been tested?
1. Unit test coverage is provided

**List any issues that this change relates to**
Relates to openculinary/knowledge-graph#53.
