### PR TITLE
Fixup: resilient handling of empty highlighting terms

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -150,7 +150,9 @@ class HashedIXSearch(object):
 
             # Advance the match window for each candidate term
             if not _is_separator(stemmed_token):
-                candidates = candidates or {term: term for term in terms}
+                candidates = candidates or {
+                    term: term for term in terms if term
+                }
                 candidates = {
                     term: tokens[1:]
                     for term, tokens in candidates.items()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -347,3 +347,13 @@ class TestSearch(unittest.TestCase):
         markup = index.highlight(doc, [term])
 
         self.assertEqual(markup, expected)
+
+    def test_empty_term_handled(self):
+        doc = "empty term example"
+        term = tuple()
+        expected = "empty term example"
+
+        index = HashedIXSearch()
+        markup = index.highlight(doc, [term])
+
+        self.assertEqual(markup, expected)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
A caller may pass an empty tuple within the list of terms to match during highlighting.  This probably doesn't make sense for the caller to do, but currently it causes an exception; we should handle this gracefully instead.

### Briefly summarize the changes
1. Omit empty terms from the list of candidate matches during highlighting

### How have the changes been tested?
1. Unit test coverage is provided