### PR TITLE
Highlighting: add limit parameter to highlight method

### DIFF
--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -130,11 +130,19 @@ class HashedIXSearch(object):
             )
             yield unstemmed_token[0], stemmed_token[0]
 
-    def highlight(self, doc, terms, case_sensitive=True, term_attributes=None):
+    def highlight(
+        self,
+        doc,
+        terms,
+        case_sensitive=True,
+        term_attributes=None,
+        limit=None,
+    ):
         # If no terms are provided to match on, do not attempt highlighting
         if not terms:
             return escape(doc)
 
+        limit = limit or -1
         term_attributes = term_attributes or {}
         token_pairs = self._token_pairs(doc, case_sensitive)
 
@@ -149,10 +157,8 @@ class HashedIXSearch(object):
         for unstemmed_token, stemmed_token in token_pairs:
 
             # Advance the match window for each candidate term
-            if not _is_separator(stemmed_token):
-                candidates = candidates or {
-                    term: term for term in terms if term
-                }
+            if not _is_separator(stemmed_token) and not limit == 0:
+                candidates = candidates or {term: term for term in terms if term}
                 candidates = {
                     term: tokens[1:]
                     for term, tokens in candidates.items()
@@ -175,6 +181,7 @@ class HashedIXSearch(object):
             if emit:
                 attributes = term_attributes.get(emit)
                 output = _render_match(accumulator, attributes)
+                limit -= 1
                 candidates = {}
                 accumulator = StringIO()
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -156,6 +156,16 @@ class TestSearch(unittest.TestCase):
 
         self.assertEqual(markup, expected)
 
+    def test_highlighting_match_limit(self):
+        doc = "one two three"
+        terms = [("one",), ("two",), ("three",)]
+        expected = "<mark>one</mark> <mark>two</mark> three"
+
+        index = HashedIXSearch()
+        markup = index.highlight(doc, terms, limit=2)
+
+        self.assertEqual(markup, expected)
+
     def test_highlighting_empty_terms(self):
         doc = "mushrooms"
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
See #29 for context.

### Briefly summarize the changes
1. Add a `limit` parameter to the `highlight` method, allowing the caller to specify the maximum number of terms to be highlighted in the output.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Implements #29.