### PR TITLE
Add benchmark test

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,68 @@
+import unittest
+
+from hashedixsearch.search import HashedIXSearch
+
+
+class TestBenchmark(unittest.TestCase):
+
+    documents = [
+        "red bell pepper diced",
+        "onions",
+        "mayonnaise",
+        "whole onion",
+        "five onions, diced",
+        "egg & bacon",
+        "one carrot",
+        "Wine",
+        "Place in Dutch Oven, and leave for one hour",
+        "daal daal daal",
+        "one two three",
+        "mushrooms",
+        "tofu",
+        "can of baked beans",
+        "sliced red bell pepper as filling",
+        "put the skewer in the frying pan",
+        "put the kebab skewers in the pan",
+        "60 ml crème fraîche",
+        "preheat the oven to 300 degrees",
+        "Step one, oven.  Phase two: pan.",
+        "food mill.",
+        "medium onion",
+        "garlic",
+        "place in the bread maker",
+        "clove",
+        "garlic",
+        "place the towel onto the place mat",
+        "empty term example",
+    ] * 100
+
+    stopwords = [
+        "diced",
+        "whole",
+    ]
+
+    queries = [
+        "tofu",
+        "egg",
+        "garlic",
+        "mushroom",
+        "beans",
+        "onion",
+        "carrot",
+        "daal",
+        "bread",
+        "nonexistent",
+        "crème",
+        "kebab",
+        "bell pepper",
+    ] * 100
+
+    def test_benchmark(self):
+        index = HashedIXSearch(stopwords=self.stopwords)
+        for doc_id, doc in enumerate(self.documents):
+            index.add(doc_id, doc)
+
+        for query in self.queries:
+            index.query(query, query_limit=5)
+            hits = index.query(query, query_limit=-1)
+            self.assertTrue(hits or query in ["mushroom", "nonexistent"], query)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
To guide future decisions around performance optimization, it's useful to have some benchmarking capability within the test suite.  At the moment this performs repeated test queries for a single index.

### Briefly summarize the changes
1. Add a benchmark test case

### How have the changes been tested?
1. Experimentation locally with the benchmark tests in combination with adjustment/removal of `StringIO` usage in the library