### PR TITLE
Refactor: cleanup stdlib imports

### DIFF
--- a/hashedixsearch/_utils.py
+++ b/hashedixsearch/_utils.py
@@ -4,7 +4,7 @@ from string import punctuation
 def _is_separator(token):
     if token.isspace():
         return True
-    if token.strip(punctuation) == str():
+    if not token.strip(punctuation):
         return True
     return False
 

--- a/hashedixsearch/_utils.py
+++ b/hashedixsearch/_utils.py
@@ -10,7 +10,7 @@ def _is_separator(token):
     return False
 
 
-def _render_match(cstring, attributes):
+def _render_match(match, attributes):
     element = Element("mark", attributes or {})
-    element.text = cstring.getvalue()
+    element.text = match
     return tostring(element, encoding="unicode")

--- a/hashedixsearch/_utils.py
+++ b/hashedixsearch/_utils.py
@@ -1,5 +1,4 @@
 from string import punctuation
-from xml.etree.ElementTree import Element, tostring
 
 
 def _is_separator(token):
@@ -11,6 +10,6 @@ def _is_separator(token):
 
 
 def _render_match(match, attributes):
-    element = Element("mark", attributes or {})
-    element.text = match
-    return tostring(element, encoding="unicode")
+    attributes = attributes or {}
+    attribs = "".join(f' {key}="{value}"' for key, value in attributes.items())
+    return f"<mark{attribs}>{match}</mark>"

--- a/hashedixsearch/search.py
+++ b/hashedixsearch/search.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from io import StringIO
 from xml.sax.saxutils import escape
 
 from hashedindex import HashedIndex
@@ -143,8 +142,8 @@ class HashedIXSearch(object):
 
         # Build up a marked-up representation of the original document
         candidates = {}
-        accumulator = StringIO()
-        markup = StringIO()
+        accumulator = ""
+        markup = ""
 
         for unstemmed_token, stemmed_token in token_pairs:
 
@@ -158,15 +157,15 @@ class HashedIXSearch(object):
                 }
 
             # We had a partial match, but it was lost
-            if accumulator.tell() and not candidates:
-                markup.write(accumulator.getvalue())
-                accumulator = StringIO()
+            if accumulator and not candidates:
+                markup += accumulator
+                accumulator = ""
 
             # Prepare the current token for output, and write it to the
             # accumulator buffer if we are within candidate highlight tokens
             output = escape(unstemmed_token)
             if candidates:
-                accumulator.write(output)
+                accumulator += output
 
             # Render highlight markup once a candidate's terms are consumed
             emit = next(filter(lambda k: not candidates[k], candidates), None)
@@ -175,11 +174,10 @@ class HashedIXSearch(object):
                 output = _render_match(accumulator, attributes)
                 limit -= 1
                 candidates = {}
-                accumulator = StringIO()
+                accumulator = ""
 
             # Write output to the markup stream when match candidates are empty
             if not candidates:
-                markup.write(output)
+                markup += output
 
-        markup.write(accumulator.getvalue())
-        return markup.getvalue()
+        return markup + accumulator


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The library has had some unusual use of `StringIO` instead of `str` variables, and maybe-unnecessary use of the `xml.etree.ElementTree` module to provide basic XML serialization.  In addition, `str()` was used for comparison to an empty string in a manner that seems uncommon.

Removing these doesn't appear to affect benchmark performance significantly (if at all), so let's use more-standard and simpler-to-understand patterns, and reduce overall dependency imports.

### Briefly summarize the changes
1. Remove use of `StringIO` buffers throughout the library
1. Remove use of `xml.etree.ElementTree` in the `_utils` module
1. Remove use of `str()` to generate an empty-string

### How have the changes been tested?
1. Unit tests continue to pass
1. Benchmark performance is unaffected